### PR TITLE
added minimal test for DD, DT neutron energy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       - name: install package with testing dependencies
         run: |
           pip install .[test]
+          pytest
 
       - name: run examples
         run: |

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,17 +2,33 @@ import pytest
 import NeSST as nst
 
 
-def test_DTprimspecmoments():
-    # checks the mean and variance value of the neutron emitted by DT fusion
+def test_DTprimspecmoments_mean():
+    # checks the mean value of the neutron emitted by DT fusion
 
     DTmean, _ = nst.DTprimspecmoments(Tion=5.0)  # units KeV
 
     assert DTmean == pytest.approx(14.1, abs=0.1)  # units MeV
 
 
-def test_DDprimspecmoments():
-    # checks the mean and variance value of the neutron emitted by DT fusion
+def test_DDprimspecmoments_mean():
+    # checks the mean value of the neutron emitted by DD fusion
 
     DTmean, _ = nst.DDprimspecmoments(Tion=5.0)  # units KeV
 
     assert DTmean == pytest.approx(2.5, abs=0.1)  # units MeV
+
+def test_DDprimspecmoments_mean_with_tion():
+    # checks the energy of the neutron increases with ion temperature
+
+    DDmean_cold, _ = nst.DDprimspecmoments(Tion=5.0)  # units KeV
+    DDmean_hot, _ = nst.DDprimspecmoments(Tion=10.0)  # units KeV
+
+    assert DDmean_cold < DDmean_hot  # units MeV
+
+def test_DTprimspecmoments_mean_with_tion():
+    # checks the energy of the neutron increases with ion temperature
+
+    DTmean_cold, _ = nst.DTprimspecmoments(Tion=5.0)  # units KeV
+    DTmean_hot, _ = nst.DTprimspecmoments(Tion=10.0)  # units KeV
+
+    assert DTmean_cold < DTmean_hot  # units MeV

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,18 @@
+import pytest
+import NeSST as nst
+
+
+def test_DTprimspecmoments():
+    # checks the mean and variance value of the neutron emitted by DT fusion
+
+    DTmean, _ = nst.DTprimspecmoments(Tion=5.0)  # units KeV
+
+    assert DTmean == pytest.approx(14.1, abs=0.1)  # units MeV
+
+
+def test_DDprimspecmoments():
+    # checks the mean and variance value of the neutron emitted by DT fusion
+
+    DTmean, _ = nst.DDprimspecmoments(Tion=5.0)  # units KeV
+
+    assert DTmean == pytest.approx(2.5, abs=0.1)  # units MeV

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -13,9 +13,9 @@ def test_DTprimspecmoments_mean():
 def test_DDprimspecmoments_mean():
     # checks the mean value of the neutron emitted by DD fusion
 
-    DTmean, _ = nst.DDprimspecmoments(Tion=5.0)  # units KeV
+    DDmean, _ = nst.DDprimspecmoments(Tion=5.0)  # units KeV
 
-    assert DTmean == pytest.approx(2.5, abs=0.1)  # units MeV
+    assert DDmean == pytest.approx(2.5, abs=0.1)  # units MeV
 
 def test_DDprimspecmoments_mean_with_tion():
     # checks the energy of the neutron increases with ion temperature

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -17,6 +17,7 @@ def test_DDprimspecmoments_mean():
 
     assert DDmean == pytest.approx(2.5, abs=0.1)  # units MeV
 
+
 def test_DDprimspecmoments_mean_with_tion():
     # checks the energy of the neutron increases with ion temperature
 
@@ -24,6 +25,7 @@ def test_DDprimspecmoments_mean_with_tion():
     DDmean_hot, _ = nst.DDprimspecmoments(Tion=10.0)  # units KeV
 
     assert DDmean_cold < DDmean_hot  # units MeV
+
 
 def test_DTprimspecmoments_mean_with_tion():
     # checks the energy of the neutron increases with ion temperature


### PR DESCRIPTION
This PR adds some minimal tests for the DTmean and DDmean neutron energy.

This is in preparation and to protect functionality for a follow up PR where I try to change the units to eV and I will want to show that things are still working.

the ci.yml file has also been changed so that these 4 tests run in the CI