### PR TITLE
added action for pypi publish

### DIFF
--- a/.github/python-publish.yml
+++ b/.github/python-publish.yml
@@ -1,0 +1,25 @@
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: python -m build
+      - name: Publish a Python distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This action will automatically make a pypi release whenever a github release is reacted 

I see that we don't make use of github releases on this repo so perhaps this PR is not wanted but I thought it was worth a try.

![Screenshot 2024-03-22 130641](https://github.com/aidancrilly/NeSST/assets/8583900/2d91d94c-ad64-4efa-9b29-cbd3d3fce1ec)

The nice thing about github releases is that they have an auto generate release details and they can be used to trigger actions (like this one).

This repo is perhaps already a trusted publisher on pypi but if not it might need [adding as a trusted publisher for the action to work](https://docs.pypi.org/trusted-publishers/adding-a-publisher/)

Anyway feel free to reject this PR as it is a bit of a change to the current release process. Just for your consideration