### PR TITLE
created instead for pypi publishing for trigger

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -2,7 +2,7 @@ name: Upload Python Package
 
 on:
   release:
-    types: [published]
+    types: [created]
     
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
If you like this could be trigger by the creation of a release instead of publishing a release.

This repo is perhaps already a trusted publisher on pypi but if not it might need adding as a trusted publisher for the action to work